### PR TITLE
Fix inconsistent indentation

### DIFF
--- a/recognize_objects.py
+++ b/recognize_objects.py
@@ -17,9 +17,9 @@ class recognize_objects:
 		self.ln = self.net.getLayerNames()
 		
 		if cv2.__version__ == '4.6.0':
-           	    self.ln = [self.ln[i - 1] for i in self.net.getUnconnectedOutLayers()]
-        	else:
-            	    self.ln = [self.ln[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
+			self.ln = [self.ln[i - 1] for i in self.net.getUnconnectedOutLayers()]
+		else:
+			self.ln = [self.ln[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
 
 	def process_frame(self, frame, all_labels, show = True):
 
@@ -91,11 +91,11 @@ class recognize_objects:
 			if len(idxs) > 0:
 				print("Objects detected in this frame:\n")
 				for i in idxs.flatten():
-				    if cv2.__version__ == '4.6.0':
-                    		        i = i
-                		    else:
-                    			i = i[0]
-				    print(self.classes[classIDs[i]])
+					if cv2.__version__ == '4.6.0':
+						i = i
+					else:
+						i = i[0]
+					print(self.classes[classIDs[i]])
 				print("\n###################################\n")
 
 		# If it is person, cat, dog detected

--- a/yolo_annotation_tool.py
+++ b/yolo_annotation_tool.py
@@ -32,8 +32,8 @@ colors = [(255, 0, 0), (255, 255, 0), (0, 255, 0), (0, 255, 255), (0, 0, 255), (
 def get_all_images(dir):
 	list_of_images = []
 	for x in os.listdir(dir):
-	    if x.endswith(".png") or x.endswith(".jpeg")  or x.endswith(".jpg") :
-	        list_of_images.append(str(dir)+str(x))
+		if x.endswith(".png") or x.endswith(".jpeg")  or x.endswith(".jpg") :
+			list_of_images.append(str(dir)+str(x))
 	return list_of_images
 
 def get_one_image(list_of_images, annotation_index):
@@ -80,7 +80,7 @@ def pre_annotate(frame, all_labels):
 
 
 def convert_list_to_str(lst):
-    return str(lst).translate(None, '[],\'')
+	return str(lst).translate(None, '[],\'')
 
 def convert_boxes_to_yolo(yolo_boxes, frame):
 	yolo_label = []
@@ -104,7 +104,7 @@ def save_annotation(frame, labels):
 	cv2.imwrite(output_dir+str(annotation_index)+".jpg", frame)
 	file=open(output_dir+str(annotation_index)+".txt",'w')
 	for items in labels:
-	    file.writelines(items+'\n')
+		file.writelines(items+'\n')
 	file.close()
 
 	print("Annotations saved as: ", labels)


### PR DESCRIPTION
Python files had some inconsistent indentation which was giving the following error

`Traceback (most recent call last):
  File "/var/www/html/Capstone/PyYAT/yolo_annotation_tool.py", line 6, in <module>
    from recognize_objects import recognize_objects
  File "/var/www/html/Capstone/PyYAT/recognize_objects.py", line 21
    else:
TabError: inconsistent use of tabs and spaces in indentation`

Fixed all inconsistent indentations